### PR TITLE
Add fallback for missing font option in canvas/text

### DIFF
--- a/modes/canvas/text.js
+++ b/modes/canvas/text.js
@@ -23,8 +23,11 @@ module.exports = Class(Base, {
 				(font.fontWeight || font['font-weight'] || '') + ' ' +
 				em + 'px ' +
 				(font.fontFamily || font['font-family'] || 'Arial');
-		} else {
+		} else if(this._font) {
 			font = this._font;
+		} else {
+			em = 12;
+			font = '12px Arial';
 		}
 
 		var lines = text && text.split(/\r?\n/);


### PR DESCRIPTION
When using react-art it's hard to understand how text is supposed to work, especially considering that

``` jsx
<Text x={10} y={10}>Hello World!</Text>
```

renders in SVG mode but not in canvas mode. 

This is because in canvas mode, without specifying `font={fontSize:12}`, `lineHeight` in `renderShapeTo` turns to `NaN` and takes the `y` parameter down with it.

Considering the dramatic lack of documentation for this otherwise excellent library we should add a fallback so that people don't get demotivated and the render behaviour stays consistent.
