### PR TITLE
Fix SyntaxErrors in compound expressions

### DIFF
--- a/core/path.js
+++ b/core/path.js
@@ -95,8 +95,8 @@ module.exports = Class({
 		if (ex == null){
 			this._pivotX = +c1x; this._pivotY = +c1y;
 			ex = +c2x; ey = +c2y;
-			c2x = (ex + (+c1x) * 2) / 3; c2y = (ey + (+c1y) * 2) / 3;
-			c1x = (x + (+c1x) * 2) / 3; c1y = (y + (+c1y) * 2) / 3;
+			c2x = ((ex + (+c1x)) * 2) / 3; c2y = ((ey + (+c1y)) * 2) / 3;
+			c1x = ((x + (+c1x)) * 2) / 3; c1y = ((y + (+c1y)) * 2) / 3;
 		} else {
 			this._pivotX = +c2x; this._pivotY = +c2y;
 		}


### PR DESCRIPTION
The additional parentheses eliminate SyntaxErrors similar to Appendix A that surface when running the default React Native iOS app with Node v5.1.

Appendix A
![iOS simulator SyntaxError screenshot](http://i.snag.gy/po7Fi.jpg)
