### PR TITLE
fix for server side rendering

### DIFF
--- a/modes/fast-noSideEffects.js
+++ b/modes/fast-noSideEffects.js
@@ -1,6 +1,6 @@
 var hasCanvas = function(){
 
-  var canvas = document.createElement('canvas');
+  var canvas = typeof window !== 'undefined' && window.document && window.document.createElement && document.createElement('canvas');
   return canvas && !!canvas.getContext;
 
 };


### PR DESCRIPTION
I'm using this package via react-art in hybrid react application. 
so when i'm trying to render my code on the server side it results in error

```
~/node_modules/art/modes/fast-noSideEffects.js:2
    var canvas = document.createElement('canvas');
                 ^

ReferenceError: document is not defined
    at hasCanvas (~/node_modules/art/modes/fast-noSideEffects.js:2:18)
    at Object.<anonymous> (~/node_modules/art/modes/fast-noSideEffects.js:6:5)
    at Module._compile (module.js:573:32)
    at Module._extensions..js (module.js:582:10)
    at Object.require.extensions.(anonymous function) [as .js] (~/node_modules/babel-register/lib/node.js:152:7)
    at Module.load (module.js:490:32)
    at tryModuleLoad (module.js:449:12)
    at Function.Module._load (module.js:441:3)
    at Module.require (module.js:500:17)
    at require (internal/module.js:20:19)
```

this patch prevents a crush