### PR TITLE
Canvas jsdom fix

### DIFF
--- a/modes/fast-noSideEffects.js
+++ b/modes/fast-noSideEffects.js
@@ -1,7 +1,7 @@
 var hasCanvas = function(){
 
   var canvas = document.createElement('canvas');
-  return canvas && !!canvas.getContext;
+  return canvas && !!canvas.getContext("2d");
 
 };
 

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "art",
   "description":  "Cross-browser Vector Graphics",
-  "version": "0.10.1",
+  "version": "0.10.2",
   "keywords": [
     "art",
     "canvas",


### PR DESCRIPTION
Because JSDom creates fake HTMLCanvasElement and adds dummy getContext method the feature detection should check the result of getContext("2d") method instead