### PR TITLE
Use escaped sequence instead of <A0> byte

### DIFF
--- a/parsers/svg/text.js
+++ b/parsers/svg/text.js
@@ -134,7 +134,7 @@ SVGParser.implement({
 
 			if (row){
 				var pad = row.pad || '';
-				row.pad = (/[\s ]*$/).exec(text)[0];
+				row.pad = (/[\s\xA0]*$/).exec(text)[0];
 				if (row.length == 0) text = text.replace(/^\s+/, '');
 				text = pad + text.replace(/\s+$/, '');
 			} else {


### PR DESCRIPTION
This file is UTF-8 compatible except for the `<A0>` byte located on the regular expression, which makes UTF-8 validators to fail. By changing it to a escaped sequence (`\xA0`), file is then both compatible in ISO-8859-1 and UTF-8.