### PR TITLE
Run requestAnimationFrame for no jank if a browser supports it

### DIFF
--- a/modes/canvas/surface.js
+++ b/modes/canvas/surface.js
@@ -2,6 +2,21 @@ var Class = require('../../core/class');
 var Container = require('../../dom/container');
 var Element = require('../../dom/native');
 
+(function() {
+  if (window.requestAnimationFrame) {
+    return;
+  }
+
+  var vendors = ['ms', 'moz', 'webkit', 'o'];
+  for (var i = 0; i < vendors.length; i++) {
+    var rafName = vendors[i] + 'RequestAnimationFrame';
+    if (window[rafName]) {
+      window.requestAnimationFrame = window[rafName];
+      break;
+    }
+  }
+})();
+
 var fps = 1000 / 60, invalids = [], renderTimer, renderInvalids = function(){
 	clearTimeout(renderTimer);
 	renderTimer = null;
@@ -102,9 +117,9 @@ var CanvasSurface = Class(Element, Container, {
 			this._valid = false;
 			invalids.push(this);
 			if (!renderTimer){
-				if (window.mozRequestAnimationFrame){
+				if (window.requestAnimationFrame){
 					renderTimer = true;
-					window.mozRequestAnimationFrame(renderInvalids);
+					window.requestAnimationFrame(renderInvalids);
 				} else {
 					renderTimer = setTimeout(renderInvalids, fps);
 				}


### PR DESCRIPTION
Existing code always run setTimeout if running browser is not firefox.
This causes jank issue in other major browsers except firefox.
Furthermore this invalidates Time Slice feature which reactjs 16.x will provide for high framerate.
This commit enables requestAnimationFrame to be run for major web browsers.

@sebmarkbage Could you review this PR?