### PR TITLE
[Bug Fix] - undefined is not an object (evaluating 'undefined.hex')

### DIFF
--- a/core/color.js
+++ b/core/color.js
@@ -193,7 +193,7 @@ Color.hex = function(hex){
 	return new Color(hex, 'hex');
 };
 
-if (this.hex == null) this.hex = Color.hex;
+if (this && this.hex == null) this.hex = Color.hex;
 
 Color.hsb = function(h, s, b, a){
 	return new Color([h || 0, s || 0, b || 0, (a == null) ? 1 : a], 'hsb');


### PR DESCRIPTION
undefined is not an object (evaluating 'undefined.hex')
https://github.com/facebook/react-native/issues/18835
